### PR TITLE
CTextureでのメモリ使用量を最適化

### DIFF
--- a/FDK19/src/04.Graphic/CTexture.cs
+++ b/FDK19/src/04.Graphic/CTexture.cs
@@ -1,5 +1,6 @@
 ﻿using SDL;
 using SkiaSharp;
+using System.Threading;
 
 namespace FDK;
 
@@ -372,8 +373,10 @@ public unsafe class CTexture : IDisposable
     private EBlendMode _eBlendMode;
     private Color _color;
     private MakeType maketype = MakeType.bytearray;
-    private SDL_FRect srcrect;
-    private SDL_FRect dstrect;
+    [ThreadStatic]
+    private static SDL_FRect srcrect;
+    [ThreadStatic]
+    private static SDL_FRect dstrect;
     //-----------------
     #endregion
 }


### PR DESCRIPTION
### 概要
CTextureの`srcrect`と`dstrect`は描画時に設定されその都度使われるため、インスタンスではなくクラス全体で共有することで、インスタンスサイズを32バイト削減します。

### 変更内容
CTextureのメンバである`srcrect`と`dstrect`をstaticに変更しました。